### PR TITLE
fix memory leak

### DIFF
--- a/RGBDConverter/RGBDConverter.cpp
+++ b/RGBDConverter/RGBDConverter.cpp
@@ -253,7 +253,7 @@ void RGBDConverter::klg2png(string filename)
 		// Write color image
 		string rgbImageName = colorFolder + to_string(timestamp) + ".png";
 		imwrite(rgbImageName, m);
-		cvReleaseMat(&p)
+		cvReleaseMat(&p);
 	}
 	fclose(logFile);
 	delete[]rgbData;

--- a/RGBDConverter/RGBDConverter.cpp
+++ b/RGBDConverter/RGBDConverter.cpp
@@ -253,6 +253,7 @@ void RGBDConverter::klg2png(string filename)
 		// Write color image
 		string rgbImageName = colorFolder + to_string(timestamp) + ".png";
 		imwrite(rgbImageName, m);
+		cvReleaseMat(&p)
 	}
 	fclose(logFile);
 	delete[]rgbData;


### PR DESCRIPTION
We found a memory leak in the loop over frames that was resulting in out of memory errors for large input files. 

